### PR TITLE
Add a button to embed an insert block token.

### DIFF
--- a/bueditor.libraries.yml
+++ b/bueditor.libraries.yml
@@ -92,3 +92,9 @@ drupal.bueditor.drupalviews:
     js/bueditor.drupalviews.js: {}
   dependencies:
     - bueditor/drupal.bueditor
+drupal.bueditor.insertblock:
+  version: VERSION
+  js:
+    js/bueditor.insertblock.js: {}
+  dependencies:
+    - bueditor/drupal.bueditor

--- a/js/bueditor.insertblock.js
+++ b/js/bueditor.insertblock.js
@@ -1,0 +1,31 @@
+(function ($, Drupal, BUE) {
+  'use strict';
+
+  /**
+   * @file
+   * Defines Views embed button for BUEditor.
+   */
+
+  /**
+   * Register buttons.
+   */
+  BUE.registerButtons('bueditor.insertblock', function() {
+    return {
+      drupalViews: {
+        id: 'insertblock',
+        label: Drupal.t('Block'),
+        text: 'Block',
+        code: BUE.block
+      }
+    };
+  });
+
+  /**
+   * Previews editor content asynchronously.
+   */
+  var bueBlock = BUE.block = function(E) {
+    E.tokenDialog('block', [
+      {name: 'block', title: BUE.t('Block id'), required: true}
+    ], BUE.t('Insert Block Token'));
+  };
+})(jQuery, Drupal, BUE);

--- a/src/Plugin/BUEditorPlugin/InsertBlock.php
+++ b/src/Plugin/BUEditorPlugin/InsertBlock.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\bueditor\Plugin\BUEditorPlugin;
+
+use Drupal\editor\Entity\Editor;
+use Drupal\bueditor\BUEditorPluginBase;
+use Drupal\bueditor\Entity\BUEditorEditor;
+use Drupal\bueditor\BUEditorToolbarWrapper;
+
+/**
+ * Defines BUEditor Embedded Views plugin.
+ *
+ * @BUEditorPlugin(
+ *   id = "insertblock",
+ *   label = "Insert Block"
+ * )
+ */
+class InsertBlock extends BUEditorPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getButtons() {
+    return [
+      'insertblock' => $this->t('Insert Block'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterEditorJS(array &$js, BUEditorEditor $bueditor_editor, Editor $editor = NULL) {
+    $toolbar = BUEditorToolbarWrapper::set($js['settings']['toolbar']);
+    // Check drupal views button.
+    if ($toolbar->has('insertblock')) {
+        $js['libraries'][] = 'bueditor/drupal.bueditor.insertblock';
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterToolbarWidget(array &$widget) {
+    // Make  drupalviews definition available to toolbar widget
+    $widget['libraries'][] = 'bueditor/drupal.bueditor.insertblock';
+  }
+
+}


### PR DESCRIPTION
- Add the block button to a bueditor
- when you click onthe button there should be 1 field for the block id
- when you click enter it should embed a [block:block_id] token
